### PR TITLE
Add async methods

### DIFF
--- a/AdoNetHelper/Database.cs
+++ b/AdoNetHelper/Database.cs
@@ -95,5 +95,71 @@ namespace AdoNetHelper
 
             return dt;
         }
+
+        public virtual async Task<int> RunQueryAsync(string query, params ParamItem[] parameters)
+        {
+            Command.Parameters.Clear();
+            Command.CommandText = query;
+            Command.CommandType = CommandType.Text;
+
+            if (parameters != null && parameters.Length > 0)
+            {
+                Command.Parameters.AddRange(ProcessParameters(parameters));
+            }
+
+            int result = 0;
+
+            await Connention.OpenAsync();
+            result = await Command.ExecuteNonQueryAsync();
+            Connention.Close();
+
+            return result;
+        }
+
+        public virtual async Task<DataTable> RunProcAsync(string procName, params ParamItem[] parameters)
+        {
+            Command.Parameters.Clear();
+            Command.CommandText = procName;
+            Command.CommandType = CommandType.StoredProcedure;
+
+            if (parameters != null && parameters.Length > 0)
+            {
+                Command.Parameters.AddRange(ProcessParameters(parameters));
+            }
+
+            DataTable dt = new DataTable();
+
+            await Connention.OpenAsync();
+            using (var reader = await Command.ExecuteReaderAsync())
+            {
+                dt.Load(reader);
+            }
+            Connention.Close();
+
+            return dt;
+        }
+
+        public virtual async Task<DataTable> GetTableAsync(string query, params ParamItem[] parameters)
+        {
+            Command.Parameters.Clear();
+            Command.CommandText = query;
+            Command.CommandType = CommandType.Text;
+
+            if (parameters != null && parameters.Length > 0)
+            {
+                Command.Parameters.AddRange(ProcessParameters(parameters));
+            }
+
+            DataTable dt = new DataTable();
+
+            await Connention.OpenAsync();
+            using (var reader = await Command.ExecuteReaderAsync())
+            {
+                dt.Load(reader);
+            }
+            Connention.Close();
+
+            return dt;
+        }
     }
 }

--- a/AdoNetHelper/SuperHelper.cs
+++ b/AdoNetHelper/SuperHelper.cs
@@ -132,6 +132,106 @@ namespace AdoNetHelper
 
             return result;
         }
+
+        public async Task<object> CreateAndRunQueryAsync(QueryType queryType, string tableName, string[] columns, object[] parameters, params KeyValuePair<string, object>[] whereParameters)
+        {
+            SqlConnection baglanti = new SqlConnection(ConnectionString);
+            SqlCommand komut = new SqlCommand();
+            komut.Connection = baglanti;
+
+            StringBuilder query = new StringBuilder(string.Empty);
+            object result = null;
+
+            Action<string[], object[]> parameterAddingAction =
+                new Action<string[], object[]>((cols, pars) =>
+                {
+                    int counter = 0;
+
+                    if (cols != null && cols.Length > 0 &&
+                        pars != null && pars.Length > 0)
+                    {
+                        komut.Parameters.AddRange(
+                           pars.Select(x =>
+                           {
+                               SqlParameter item = new SqlParameter($"@{cols[counter]}", x);
+                               counter++;
+                               return item;
+                           }).ToArray());
+                    }
+                });
+
+
+            switch (queryType)
+            {
+                case QueryType.Insert:
+                    query.Append($"INSERT INTO {tableName}(");
+                    query.Append(string.Join(",", columns));
+                    query.Append(") VALUES (");
+                    query.Append(string.Join(",", columns.Select(x => $"@{x} ")));
+                    query.Append(")");
+
+                    parameterAddingAction(columns, parameters);
+                    break;
+                case QueryType.Update:
+                    query.Append($"UPDATE {tableName} SET ");
+                    query.Append(string.Join(",", columns.Select(x => $"{x}=@{x} ")));
+
+                    parameterAddingAction(columns, parameters);
+                    break;
+                case QueryType.Delete:
+                    query.Append($"DELETE FROM {tableName} ");
+                    break;
+                case QueryType.Select:
+                    query.Append($"SELECT ");
+                    query.Append(string.Join(",", columns.Select(x => $"{x} ")));
+                    query.Append($"FROM {tableName}");
+                    break;
+                default:
+                    break;
+            }
+
+            if (whereParameters != null && whereParameters.Length > 0)
+            {
+                query.Append(" WHERE ");
+                query.Append(string.Join(" AND ", whereParameters.Select(x => $"{x.Key}=@p_{x.Key}")));
+
+                parameterAddingAction(
+                    whereParameters.Select(x => $"p_{x.Key}").ToArray(),
+                    whereParameters.Select(x => x.Value).ToArray());
+            }
+
+            komut.CommandText = query.ToString();
+
+            switch (queryType)
+            {
+                case QueryType.Insert:
+                case QueryType.Update:
+                case QueryType.Delete:
+                    await baglanti.OpenAsync();
+                    result = await komut.ExecuteNonQueryAsync();
+                    baglanti.Close();
+                    break;
+
+                case QueryType.Select:
+                    DataTable dt = new DataTable(tableName);
+                    await baglanti.OpenAsync();
+                    using (var reader = await komut.ExecuteReaderAsync())
+                    {
+                        dt.Load(reader);
+                    }
+                    baglanti.Close();
+                    result = dt;
+                    break;
+
+                default:
+                    break;
+            }
+
+            komut.Dispose();
+            baglanti.Dispose();
+
+            return result;
+        }
     }
 
     public enum QueryType

--- a/README.md
+++ b/README.md
@@ -90,3 +90,18 @@ Debug.WriteLine("Result table row count(RunProc - MyStoredProc1) : " + dt.Rows.C
 DB.RunProc("MyStoredProc2",
     new ParamItem() { ParamName = "@NewPrice", ParamValue = 29m });
 ```
+
+### Async usage
+```c#
+// Example of using async methods
+int affectedRows = await DB.RunQueryAsync(
+    "INSERT INTO Books(Name, Author, Description, Price) VALUES(@Name, @Author, @Desc, @Price)",
+    new ParamItem() { ParamName = "@Name", ParamValue = "Jungle Book" },
+    new ParamItem() { ParamName = "@Author", ParamValue = "K. Murat Başeren" },
+    new ParamItem() { ParamName = "@Desc", ParamValue = "About book subject" },
+    new ParamItem() { ParamName = "@Price", ParamValue = 25 });
+
+DataTable asyncTable = await DB.GetTableAsync(
+    "SELECT Id, Name, Author, Description, Price FROM Books WHERE Price > @PriceVal",
+    new ParamItem() { ParamName = "@PriceVal", ParamValue = 25m });
+```


### PR DESCRIPTION
## Summary
- add async versions of `RunQuery`, `RunProc` and `GetTable`
- add `CreateAndRunQueryAsync` for SuperHelper
- document async usage in README

## Testing
- `dotnet build AdoNetHelper/AdoNetHelper.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f7164e20832085101103a1ff4ac8