### PR TITLE
Add SQL function helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,16 @@ DataTable asyncTable = await DB.GetTableAsync(
     "SELECT Id, Name, Author, Description, Price FROM Books WHERE Price > @PriceVal",
     new ParamItem() { ParamName = "@PriceVal", ParamValue = 25m });
 ```
+
+### RunFunction usage
+```c#
+// Example of calling a SQL function that returns table
+DataTable fnTable = DB.RunFunction("dbo.GetBooksByPrice",
+    new ParamItem() { ParamName = "@MinPrice", ParamValue = 10m },
+    new ParamItem() { ParamName = "@MaxPrice", ParamValue = 20m });
+
+// Async version
+DataTable asyncFnTable = await DB.RunFunctionAsync("dbo.GetBooksByPrice",
+    new ParamItem() { ParamName = "@MinPrice", ParamValue = 10m },
+    new ParamItem() { ParamName = "@MaxPrice", ParamValue = 20m });
+```


### PR DESCRIPTION
## Summary
- add constructor to build connection string from parameters
- support running SQL functions via `RunFunction` and `RunFunctionAsync`
- document new function helpers in README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fe37dbd88320930d1c3689267f20