### PR TITLE
Add Backup/Restore methods and PDF export docs

### DIFF
--- a/AdoNetHelper/Database.cs
+++ b/AdoNetHelper/Database.cs
@@ -2,6 +2,7 @@
 using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using System;
 
 namespace AdoNetHelper
 {
@@ -129,6 +130,60 @@ namespace AdoNetHelper
             da.Fill(dt);
 
             return dt;
+        }
+
+        /// <summary>
+        /// Creates a backup file for the specified database.
+        /// </summary>
+        /// <param name="databaseName">Name of the database to backup.</param>
+        /// <param name="filePath">Full path of the backup file.</param>
+        public virtual void Backup(string databaseName, string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(databaseName))
+            {
+                throw new ArgumentNullException(nameof(databaseName));
+            }
+
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            Command.Parameters.Clear();
+            Command.CommandText = $"BACKUP DATABASE [{databaseName}] TO DISK = @filePath";
+            Command.CommandType = CommandType.Text;
+            Command.Parameters.AddWithValue("@filePath", filePath);
+
+            Connection.Open();
+            Command.ExecuteNonQuery();
+            Connection.Close();
+        }
+
+        /// <summary>
+        /// Restores the specified database from a backup file.
+        /// </summary>
+        /// <param name="databaseName">Name of the database to restore.</param>
+        /// <param name="filePath">Path of the backup file.</param>
+        public virtual void Restore(string databaseName, string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(databaseName))
+            {
+                throw new ArgumentNullException(nameof(databaseName));
+            }
+
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            Command.Parameters.Clear();
+            Command.CommandText = $"RESTORE DATABASE [{databaseName}] FROM DISK = @filePath WITH REPLACE";
+            Command.CommandType = CommandType.Text;
+            Command.Parameters.AddWithValue("@filePath", filePath);
+
+            Connection.Open();
+            Command.ExecuteNonQuery();
+            Connection.Close();
         }
 
         public virtual async Task<int> RunQueryAsync(string query, params ParamItem[] parameters)

--- a/README.md
+++ b/README.md
@@ -118,3 +118,20 @@ DataTable asyncFnTable = await DB.RunFunctionAsync("dbo.GetBooksByPrice",
     new ParamItem() { ParamName = "@MinPrice", ParamValue = 10m },
     new ParamItem() { ParamName = "@MaxPrice", ParamValue = 20m });
 ```
+
+### Export sınıfı kullanımı
+```c#
+// DataTable verisini PDF dosyasına dönüştürme
+Export exporter = new Export();
+byte[] pdfBytes = await exporter.ToPdfAsync(dt);
+File.WriteAllBytes(@"C:\\temp\\table.pdf", pdfBytes);
+```
+
+### Backup ve Restore metodları
+```c#
+// Veritabanı yedeği oluşturma
+DB.Backup("BookDb", @"C:\\temp\\BookDb.bak");
+
+// Yedekten veritabanını geri yükleme
+DB.Restore("BookDb", @"C:\\temp\\BookDb.bak");
+```


### PR DESCRIPTION
## Summary
- implement `Backup` and `Restore` methods in `Database` class
- add documentation and examples for export, backup and restore features

## Testing
- `msbuild AdoNetHelper.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0994f0bc83208ef76a852ae4276e