### PR TITLE
Add transaction helpers

### DIFF
--- a/AdoNetHelper/Database.cs
+++ b/AdoNetHelper/Database.cs
@@ -26,6 +26,11 @@ namespace AdoNetHelper
         /// </summary>
         public SqlCommand Command { get; private set; }
 
+        /// <summary>
+        /// Gets the SQL transaction object.
+        /// </summary>
+        public SqlTransaction Transaction { get; private set; }
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Database"/> class using the specified connection string.
@@ -58,6 +63,64 @@ namespace AdoNetHelper
             ConnectionString = builder.ConnectionString;
             Connection = new SqlConnection(ConnectionString);
             Command = Connection.CreateCommand();
+        }
+
+        /// <summary>
+        /// Begins a SQL transaction and assigns it to the command.
+        /// </summary>
+        public void BeginTransaction()
+        {
+            if (Connection.State != ConnectionState.Open)
+            {
+                Connection.Open();
+            }
+
+            Transaction = Connection.BeginTransaction();
+            Command.Transaction = Transaction;
+        }
+
+        /// <summary>
+        /// Begins a SQL transaction asynchronously and assigns it to the command.
+        /// </summary>
+        public async Task BeginTransactionAsync()
+        {
+            if (Connection.State != ConnectionState.Open)
+            {
+                await Connection.OpenAsync();
+            }
+
+            Transaction = Connection.BeginTransaction();
+            Command.Transaction = Transaction;
+        }
+
+        /// <summary>
+        /// Commits the current SQL transaction.
+        /// </summary>
+        public void Commit()
+        {
+            if (Transaction == null)
+            {
+                throw new InvalidOperationException("Transaction has not been started.");
+            }
+
+            Transaction.Commit();
+            Transaction = null;
+            Connection.Close();
+        }
+
+        /// <summary>
+        /// Rolls back the current SQL transaction.
+        /// </summary>
+        public void Rollback()
+        {
+            if (Transaction == null)
+            {
+                throw new InvalidOperationException("Transaction has not been started.");
+            }
+
+            Transaction.Rollback();
+            Transaction = null;
+            Connection.Close();
         }
 
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ await DB.CloneTableStructureAsync("Books", "BooksCopy");
 await DB.CloneTableWithDataAsync("Books", "BooksCopyWithData");
 ```
 
-### Transaction kullanımı
+### Transaction kullanımı (Henüz Test Edilmedi !!)
 ```c#
 // Transaction başlatma
 await DB.BeginTransactionAsync();

--- a/README.md
+++ b/README.md
@@ -165,3 +165,21 @@ await DB.CloneTableStructureAsync("Books", "BooksCopy");
 // Yapı ve verilerle beraber kopya oluşturma
 await DB.CloneTableWithDataAsync("Books", "BooksCopyWithData");
 ```
+
+### Transaction kullanımı
+```c#
+// Transaction başlatma
+await DB.BeginTransactionAsync();
+try
+{
+    DB.RunQuery("UPDATE Books SET Price = Price + 1");
+    DB.RunQuery("INSERT INTO Logs(Message) VALUES(@msg)",
+        new ParamItem() { ParamName = "@msg", ParamValue = "Prices updated" });
+    DB.Commit();
+}
+catch
+{
+    DB.Rollback();
+    throw;
+}
+```


### PR DESCRIPTION
## Summary
- add transaction helper properties/methods
- document transaction usage

## Testing
- `dotnet build AdoNetHelper.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1dcce9fc83208c46798ea917da77